### PR TITLE
Update redirects.map to remove deprecated ladspa module

### DIFF
--- a/provisioning/nginx/redirects.map
+++ b/provisioning/nginx/redirects.map
@@ -1574,7 +1574,6 @@
 /freeswitch/confluence-to-docs-redirector/display/FREESWITCH/mod_java /freeswitch/FreeSWITCH-Explained/Modules/mod_java_3966491;
 /freeswitch/confluence-to-docs-redirector/display/FREESWITCH/mod_json_cdr /freeswitch/FreeSWITCH-Explained/Modules/mod_json_cdr_4653124;
 /freeswitch/confluence-to-docs-redirector/display/FREESWITCH/mod_kazoo /freeswitch/FreeSWITCH-Explained/Modules/mod_kazoo_10683641;
-/freeswitch/confluence-to-docs-redirector/display/FREESWITCH/mod_ladspa /freeswitch/FreeSWITCH-Explained/Modules/mod_ladspa_6587118;
 /freeswitch/confluence-to-docs-redirector/display/FREESWITCH/mod_lcr /freeswitch/FreeSWITCH-Explained/Modules/mod_lcr_6587457;
 /freeswitch/confluence-to-docs-redirector/display/FREESWITCH/mod_ldap /freeswitch/FreeSWITCH-Explained/Modules/mod_ldap_6587459;
 /freeswitch/confluence-to-docs-redirector/display/FREESWITCH/mod_local_stream /freeswitch/FreeSWITCH-Explained/Modules/mod_local_stream_6587466;


### PR DESCRIPTION
Removing link in redirects.map to removed deprecated ladspa module.